### PR TITLE
updated the base DataAccess classes and rolled in the generic Get, so…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.1.0
+### Rolled up ```IBaseDataAccess<TIdType>```/```BaseDataAccess<TIdType>``` into their base classes
+Updated the root base interface/class to include the generic ```Get``` method, because it's possible the user would build
+a database where most records have an ```int``` primary key, but on one large transaction table you'd prefer to use ```long```
+and yet in another you'd want to use ```Guid``` so you can share the key across contexts.  The original implementation
+only allowed one type of primary key.
+
 # v2.0.0
 ### Updated to support .net 5.0
 Updated a few things, unfortunately it removed a little bit of functionality, so it counts as a major update, 
@@ -22,22 +29,22 @@ ProphetsWay.Example references a NuGet reference to this project, albeit a sligh
 
 
 # v1.1.0
-### New Interfaces IBaseIdEntity< T > and IBaseDataAccess< T >
+### New Interfaces ```IBaseIdEntity<T>``` and ```IBaseDataAccess<T>```
 For added functionality/flexibility, I added some code to specify the ID property of your entities, as well as its type.
 Then was able to refactor the BaseDataAccess classes to make use of these new features.
 
-Old classes are marked as Obsolete, but are still usabled, all changes are backwards compatible.
+Old classes are marked as Obsolete, but are still usable, all changes are backwards compatible.
 
-##### IBaseIdEntity< T >
+##### ```IBaseIdEntity<T>```
 Created a new optional interface, IBaseIdEntity, which inherits from IBaseEntity for backwards compatibility
 but this new interface will specify a property "Id" that must exist on your entities, and the type of the Id is 
 specified by the generic passed in.  In general its likely to be either int, long, or a Guid.
 
-##### IBaseDataAccess< T >
+##### ```IBaseDataAccess<T>```
 Created a new interface to replace the two older options ```IBaseDataAccessInt``` and ```IBaseDataAccessLong```.
 Now supports ```Guid``` id types.
 
-##### BaseDataAccess< TIdType >
+##### ```BaseDataAccess<TIdType>```
 Created a new base abstract class to replace the two older options ```BaseDataAccessInt``` and ```BaseDataAccessLong```.
 Now supports ```Guid``` id types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Updated the root base interface/class to include the generic ```Get``` method, because it's possible the user would build
 a database where most records have an ```int``` primary key, but on one large transaction table you'd prefer to use ```long```
 and yet in another you'd want to use ```Guid``` so you can share the key across contexts.  The original implementation
-only allowed one type of primary key.
+only allowed one type of primary key.  Tagged the old methods as Obsolete, but using them will give you a warning, suggestion
+includes the note to simply remove the generic assignment.
+
 
 # v2.0.0
 ### Updated to support .net 5.0

--- a/ProphetsWay.BaseDataAccess/BaseDataAccess.cs
+++ b/ProphetsWay.BaseDataAccess/BaseDataAccess.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace ProphetsWay.BaseDataAccess
 {
@@ -36,11 +37,17 @@ namespace ProphetsWay.BaseDataAccess
         /// <summary>
         /// Assumes that your ID property on your entities is either named "Id" or "EntityTypeNameId"
         /// </summary>
-        public T Get<T, TIdType>(TIdType id)
+        public virtual T Get<T, TIdType>(TIdType id)
             where T : IBaseEntity, new()
             where TIdType : struct
         {
             return this.GetMethodFindAndSetIdPropertyAndInvoke<T>(id);
         }
+    }
+
+    [Obsolete("You no longer need to use this Generic type of BaseDataAccess, you can use the normal BaseDataAccess. (just remove the generic assignment)", false)]    
+    public abstract class BaseDataAccess<TIdType> : BaseDataAccess, IBaseDataAccess<TIdType>
+    {
+
     }
 }

--- a/ProphetsWay.BaseDataAccess/BaseDataAccess.cs
+++ b/ProphetsWay.BaseDataAccess/BaseDataAccess.cs
@@ -32,17 +32,13 @@ namespace ProphetsWay.BaseDataAccess
         public abstract void TransactionRollBack();
 
         public abstract void TransactionStart();
-    }
 
-    /// <summary>
-    /// Utilizes Reflection to identify which methods to call, if you prefer to manually check for the sake of speed, do not inherit this class
-    /// </summary>
-    public abstract class BaseDataAccess<TIdType> : BaseDataAccess, IBaseDataAccess<TIdType>
-    {
         /// <summary>
         /// Assumes that your ID property on your entities is either named "Id" or "EntityTypeNameId"
         /// </summary>
-        public virtual T Get<T>(TIdType id) where T : IBaseEntity, new()
+        public T Get<T, TIdType>(TIdType id)
+            where T : IBaseEntity, new()
+            where TIdType : struct
         {
             return this.GetMethodFindAndSetIdPropertyAndInvoke<T>(id);
         }

--- a/ProphetsWay.BaseDataAccess/IBaseDataAccess.cs
+++ b/ProphetsWay.BaseDataAccess/IBaseDataAccess.cs
@@ -43,20 +43,13 @@ namespace ProphetsWay.BaseDataAccess
 		/// allows the business layer logic to wrap many calls within a transaction 
 		/// </summary>
 		void TransactionRollBack();
-	}
 
-	/// <summary>
-	/// An interface to define some basic calls your Base DAL should have accessible.
-	/// Adds a nice shortcut method for your TIdType based index key, inherits IBaseDataAccess
-	/// </summary>
-	public interface IBaseDataAccess<TIdType> : IBaseDataAccess
-	{
 		/// <summary>
 		/// A global version of 'Get' that can be implemented in your base DAL class,
 		/// Allows for a simple get call without instantiating an object and 
 		/// manually setting the ID field everywhere used in your business logic layers.
 		/// Implies your ID properties are of type TIdType.
 		/// </summary>
-		TEntityType Get<TEntityType>(TIdType id) where TEntityType : IBaseEntity, new();
+		TEntityType Get<TEntityType, TIdType>(TIdType id) where TEntityType : IBaseEntity, new() where TIdType : struct;
 	}
 }

--- a/ProphetsWay.BaseDataAccess/IBaseDataAccess.cs
+++ b/ProphetsWay.BaseDataAccess/IBaseDataAccess.cs
@@ -52,4 +52,10 @@ namespace ProphetsWay.BaseDataAccess
 		/// </summary>
 		TEntityType Get<TEntityType, TIdType>(TIdType id) where TEntityType : IBaseEntity, new() where TIdType : struct;
 	}
+
+	[Obsolete("You no longer need to use this Generic type of IBaseDataAccess, you can use the normal IBaseDataAccess. (just remove the generic assignment)", false)]
+	public interface IBaseDataAccess<TIdType> : IBaseDataAccess
+	{
+
+	}
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
 
 variables:
   MajorVersion: '2'
-  MinorVersion: '0'
+  MinorVersion: '1'
   PatchVersion: '0'
 
 


### PR DESCRIPTION
… you can use more than a single primary key type across all your entities/tables

Fixes: #13 